### PR TITLE
ZP-1643 BackendIMAP: Remove "Bcc" header from outgoing mail and fix sending mails without "To" header.

### DIFF
--- a/src/backend/imap/imap.php
+++ b/src/backend/imap/imap.php
@@ -2639,7 +2639,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
         if (is_array($toaddr)) {
             $recipients = $toaddr;
         }
-        else {
+        elseif ($toaddr !== "") {
             $recipients = array($toaddr);
         }
 

--- a/src/backend/imap/imap.php
+++ b/src/backend/imap/imap.php
@@ -251,6 +251,10 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
             $message->headers["cc"] = Utils::CheckAndFixEncodingInHeadersOfSentMail($Mail_RFC822->parseAddressList($message->headers["cc"], null, null, false, null));
         }
 
+        if (isset($message->headers["bcc"])) {
+            $message->headers["bcc"] = Utils::CheckAndFixEncodingInHeadersOfSentMail($Mail_RFC822->parseAddressList($message->headers["bcc"], null, null, false, null));
+        }
+
         unset($Mail_RFC822);
 
         if (isset($message->headers["subject"]) && mb_detect_encoding($message->headers["subject"], "UTF-8") != false && preg_match('/[^\x00-\x7F]/', $message->headers["subject"]) == 1) {
@@ -2639,7 +2643,7 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
             $recipients = array($toaddr);
         }
 
-        // Cc and Bcc headers are sent, but we need to make sure that the recipient list contains them
+        // add Bcc and Cc header fields to recipients
         foreach (array("CC", "cc", "Cc", "BCC", "Bcc", "bcc") as $key) {
             if (!empty($headers[$key])) {
                 if (is_array($headers[$key])) {
@@ -2647,6 +2651,11 @@ class BackendIMAP extends BackendDiff implements ISearchProvider {
                 }
                 else {
                     $recipients[] = $headers[$key];
+                }
+
+                // remove BCC header field from message
+                if (strcasecmp($key, "BCC") == 0) {
+                    unset($headers[$key]);
                 }
             }
         }


### PR DESCRIPTION
Released under the Affero GNU General Public License (AGPL) version 3.