### PR TITLE
ZP-1579 mimeDecode.php: Use mbstring instead of iconv to improve handling with illegal characters.

### DIFF
--- a/src/include/mimeDecode.php
+++ b/src/include/mimeDecode.php
@@ -825,15 +825,13 @@ class Mail_mimeDecode
                     break;
             }
             if (is_string($this->_decode_headers) && $charset != $this->_decode_headers) {
-                $conv = @iconv($charset, $this->_decode_headers, $text);
-                $text = ($conv === false) ? $text : $conv;
+                $text = @iconv($charset, $this->_decode_headers . '//IGNORE', $text);
             }
             $input = str_replace($encoded, $text, $input);
         }
 
         if ($default_charset  && is_string($this->_decode_headers) && $charset != $this->_decode_headers) {
-            $conv = @iconv($charset, $this->_decode_headers, $input); // TODO: shouldn't this be $default_charset ?
-            $input = ($conv === false) ? $input : $conv;
+            $input = @iconv($charset, $this->_decode_headers . '//IGNORE', $input); // TODO: shouldn't this be "$default_charset"?
         }
 
         return $input;
@@ -862,8 +860,7 @@ class Mail_mimeDecode
                 break;
         }
         if ($detectCharset && strtolower($charset) != $this->_charset) {
-            $conv = @iconv($charset, $this->_charset, $input);
-            $input = ($conv === false) ? $input : $conv;
+            $input = @iconv($charset, $this->_charset . '//IGNORE', $input);
         }
 
         return $input;

--- a/src/include/mimeDecode.php
+++ b/src/include/mimeDecode.php
@@ -154,7 +154,7 @@ class Mail_mimeDecode
 
     /**
      * Flag to determine whether to decode headers
-     * (set to UTF8 to iconv convert headers)
+     * (set to UTF8 to convert headers)
      * @var    mixed
      * @access private
      */
@@ -234,20 +234,15 @@ class Mail_mimeDecode
 
         // Called via an object
         } else {
-            $this->_include_bodies = isset($params['include_bodies']) ?
-                                 $params['include_bodies'] : false;
-            $this->_decode_bodies  = isset($params['decode_bodies']) ?
-                                 $params['decode_bodies']  : false;
-            $this->_decode_headers = isset($params['decode_headers']) ?
-                                 $params['decode_headers'] : false;
-            $this->_rfc822_bodies  = isset($params['rfc_822bodies']) ?
-                                 $params['rfc_822bodies']  : false;
-            $this->_charset = isset($params['charset']) ?
-                                 strtolower($params['charset']) : 'utf-8';
+            $this->_include_bodies = isset($params['include_bodies']) ? $params['include_bodies'] : false;
+            $this->_decode_bodies  = isset($params['decode_bodies']) ? $params['decode_bodies']  : false;
+            $this->_decode_headers = isset($params['decode_headers']) ? $params['decode_headers'] : false;
+            $this->_rfc822_bodies  = isset($params['rfc_822bodies']) ? $params['rfc_822bodies']  : false;
+            $this->_charset = isset($params['charset']) ? strtolower($params['charset']) : 'utf-8';
 
             if (is_string($this->_decode_headers)) {
-                if (!function_exists('iconv')) {
-                    $this->raiseError('header decode conversion requested, however iconv is missing');
+                if (!function_exists('mb_convert_encoding')) {
+                    $this->raiseError('header decode conversion requested, however mbstring is missing');
                 }
                 $this->_decode_headers = strtolower($this->_decode_headers);
             }
@@ -825,13 +820,32 @@ class Mail_mimeDecode
                     break;
             }
             if (is_string($this->_decode_headers) && $charset != $this->_decode_headers) {
-                $text = @iconv($charset, $this->_decode_headers . '//IGNORE', $text);
+                if (@mb_check_encoding($text, $charset) == false) {
+                    // list of encodings, sorted by priority to assist mb_detect_encoding()
+                    $encodingPriority = array('UTF-8', 'SJIS', 'GB18030', 'ISO-8859-1', 'ISO-8859-2', 'ISO-8859-3', 'ISO-8859-4',
+                        'ISO-8859-5', 'ISO-8859-6', 'ISO-8859-7', 'ISO-8859-8', 'ISO-8859-9', 'ISO-8859-10', 'ISO-8859-13',
+                        'ISO-8859-14', 'ISO-8859-15', 'ISO-8859-16', 'WINDOWS-1252', 'WINDOWS-1251', 'EUC-JP', 'EUC-TW',
+                        'KOI8-R', 'BIG-5', 'ISO-2022-KR', 'ISO-2022-JP-MS');
+
+                    // only use encodings supported by the system
+                    $encodings = array_unique(array_merge($encodingPriority, mb_list_encodings()));
+
+                    // detect suitable encoding
+                    if (@mb_check_encoding($text, ($encoding = mb_detect_encoding($text, $encodings)))) {
+                        ZLog::Write(LOGLEVEL_WARN, sprintf("mimeDecode::_decodeHeader(): invalid encoding in header: using '%s' instead of '%s'", $encoding, $charset));
+                        $charset = $encoding;
+                    }
+                    else {
+                        ZLog::Write(LOGLEVEL_WARN, sprintf("mimeDecode::_decodeHeader(): invalid encoding '%s' used in header, no substitution found", $charset));
+                    }
+                }
+                $text = @mb_convert_encoding($text, $this->_decode_headers, $charset);
             }
             $input = str_replace($encoded, $text, $input);
         }
 
-        if ($default_charset  && is_string($this->_decode_headers) && $charset != $this->_decode_headers) {
-            $input = @iconv($charset, $this->_decode_headers . '//IGNORE', $input); // TODO: shouldn't this be "$default_charset"?
+        if ($default_charset && is_string($this->_decode_headers) && $default_charset != $this->_decode_headers) {
+            $input = mb_convert_encoding($input, $this->_decode_headers, $default_charset);
         }
 
         return $input;
@@ -859,8 +873,28 @@ class Mail_mimeDecode
                 $input = base64_decode($input);
                 break;
         }
+
         if ($detectCharset && strtolower($charset) != $this->_charset) {
-            $input = @iconv($charset, $this->_charset . '//IGNORE', $input);
+            if (@mb_check_encoding($input, $charset) == false) {
+                // list of encodings, sorted by priority to assist mb_detect_encoding()
+                $encodingPriority = array('UTF-8', 'SJIS', 'GB18030', 'ISO-8859-1', 'ISO-8859-2', 'ISO-8859-3', 'ISO-8859-4',
+                    'ISO-8859-5', 'ISO-8859-6', 'ISO-8859-7', 'ISO-8859-8', 'ISO-8859-9', 'ISO-8859-10', 'ISO-8859-13',
+                    'ISO-8859-14', 'ISO-8859-15', 'ISO-8859-16', 'WINDOWS-1252', 'WINDOWS-1251', 'EUC-JP', 'EUC-TW',
+                    'KOI8-R', 'BIG-5', 'ISO-2022-KR', 'ISO-2022-JP-MS');
+
+                // only use encodings supported by the system
+                $encodings = array_unique(array_merge($encodingPriority, mb_list_encodings()));
+
+                // detect suitable encoding
+                if (@mb_check_encoding($input, ($encoding = mb_detect_encoding($input, $encodings)))) {
+                    ZLog::Write(LOGLEVEL_WARN, sprintf("mimeDecode::_decodeBody(): invalid encoding in body: using '%s' instead of '%s'", $encoding, $charset));
+                    $charset = $encoding;
+                }
+                else {
+                    ZLog::Write(LOGLEVEL_WARN, sprintf("mimeDecode::_decodeBody(): invalid encoding '%s' used in body, no substitution found", $charset));
+                }
+            }
+            $input = @mb_convert_encoding($input, $this->_decode_headers, $charset);
         }
 
         return $input;


### PR DESCRIPTION
Released under the Affero GNU General Public License (AGPL) version 3.